### PR TITLE
Check for an open connection at query execution time

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ requirements
 
 * unixODBC binaries and development libraries for module compilation
   * on Ubuntu/Debian `sudo apt-get install unixodbc unixodbc-dev`
+  * on RedHat/CentOS `sudo yum install unixODBC unixODBC-devel`
   * on OSX using macports.org `sudo port unixODBC`
 * odbc drivers for target database
 * properly configured odbc.ini and odbcinst.ini.

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,6 +26,9 @@
           ]
         }],
         [ 'OS == "mac"', {
+          'include_dirs': [
+            '/usr/local/include'
+          ],
           'libraries' : [
             '-L/usr/local/lib',
             '-lodbc' 

--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -1,170 +1,168 @@
-declare module 'odbc' {
-    function odbc(options?: odbc.DatabaseOptions): odbc.Database;
+declare function odbc(options?: odbc.DatabaseOptions): odbc.Database;
 
-    namespace odbc {
-        export const SQL_CLOSE: number;
-        export const SQL_DROP: number;
-        export const SQL_UNBIND: number;
-        export const SQL_RESET_PARAMS: number;
-        export const SQL_DESTROY: number;
-        export const FETCH_ARRAY: number;
-        export const FETCH_OBJECT: number;
+declare namespace odbc {
+    export const SQL_CLOSE: number;
+    export const SQL_DROP: number;
+    export const SQL_UNBIND: number;
+    export const SQL_RESET_PARAMS: number;
+    export const SQL_DESTROY: number;
+    export const FETCH_ARRAY: number;
+    export const FETCH_OBJECT: number;
 
-        export let debug: boolean;
+    export let debug: boolean;
 
-        export interface ConnctionInfo {
-            [key: string]: string;
-        }
-
-        export interface DatabaseOptions {
-            connectTimeout?: number;
-            loginTimeout?: number;
-        }
-
-        export interface DescribeOptions {
-            database: string;
-            schema?: string;
-            table?: string;
-            type?: string;
-            column?: string;
-        }
-
-        export interface SimpleQueue {
-            push(fn: Function): void;
-            next(): any;
-            maybeNext(): any;
-        }
-
-        export interface ODBCTable {
-            TABLE_CAT: string;
-            TABLE_SCHEM: string;
-            TABLE_NAME: string;
-            TABLE_TYPE: string;
-            REMARKS: string;
-        }
-
-        export interface ODBCColumn {
-            TABLE_CAT: string;
-            TABLE_SCHEM: string;
-            TABLE_NAME: string;
-            COLUMN_NAME: string;
-            DATA_TYPE: number;
-            TYPE_NAME: string;
-            COLUMN_SIZE: number;
-            BUFFER_LENGTH: number;
-            DECIMAL_DIGITS: number;
-            NUM_PREC_RADIX: number;
-            NULLABLE: number;
-            REMARKS: string;
-            COLUMN_DEF: string;
-            SQL_DATA_TYPE: number;
-            SQL_DATETIME_SUB: number;
-            CHAR_OCTET_LENGTH: number;
-            ORDINAL_POSITION: number;
-            IS_NULLABLE: string;
-        }
-
-        export interface ODBCConnection {
-            connected: boolean;
-            connectTimeout: number;
-            loginTimeout: number;
-            open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
-            openSync(connctionString: string | ConnctionInfo): void;
-            close(cb: (err: any) => void): void;
-            closeSync(): void;
-            createStatement(cb: (err: any, stmt: ODBCStatement) => void): void;
-            createStatementSync(): ODBCStatement;
-            query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
-            query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
-            querySync(sql: string, bindingParameters?: any[]): ResultRow[];
-            beginTransaction(cb: (err: any) => void): void;
-            beginTransactionSync(): void;
-            endTransaction(rollback: boolean, cb: (err: any) => void): void;
-            endTransactionSync(rollback: boolean): void;
-            tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCResult) => void): void;
-            columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCResult) => void): void;
-        }
-
-        export interface ResultRow {
-            [key: string]: any;
-        }
-
-        export interface ODBCResult {
-            fetchMode: number;
-            fetchAll(cb: (err: any, data: ResultRow[]) => void): void;
-            fetchAllSync(): ResultRow[];
-            fetch(cb: (err: any, data: ResultRow) => void): void;
-            fetchSync(): ResultRow;
-            closeSync(): void;
-            moreResultsSync(): any;
-            getColumnNamesSync(): string[];
-        }
-
-        export interface ODBCStatement {
-            queue: SimpleQueue;
-            execute(cb: (err: any, result: ODBCResult) => void): void;
-            execute(bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
-            executeSync(bindingParameters?: any[]): ODBCResult;
-            executeDirect(sql: string, cb: (err: any, result: ODBCResult) => void): void;
-            executeDirect(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
-            executeDirectSync(sql: string, bindingParameters?: any[]): ODBCResult;
-            executeNonQuery(cb: (err: any, result: number) => void): void;
-            executeNonQuery(bindingParameters: any[], cb: (err: any, result: number) => void): void;
-            executeNonQuerySync(bindingParameters?: any[]): number;
-            prepare(sql: string, cb: (err: any) => void): void;
-            prepareSync(sql: string): void;
-            bind(bindingParameters: any[], cb: (err: any) => void): void;
-            bindSync(bindingParameters: any[]): void;
-            closeSync(): void;
-        }
-
-        export class Database {
-            constructor(options?: DatabaseOptions);
-            conn: ODBCConnection;
-            queue: SimpleQueue;
-            connected: boolean;
-            connectTimeout: number;
-            loginTimeout: number;
-            SQL_CLOSE: number;
-            SQL_DROP: number;
-            SQL_UNBIND: number;
-            SQL_RESET_PARAMS: number;
-            SQL_DESTROY: number;
-            FETCH_ARRAY: number;
-            FETCH_OBJECT: number;
-            open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
-            openSync(connctionString: string | ConnctionInfo): void;
-            close(cb: (err: any) => void): void;
-            closeSync(): void;
-            query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
-            query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
-            querySync(sql: string, bindingParameters?: any[]): ResultRow[];
-            queryResult(sql: string, cb: (err: any, result: ODBCResult) => void): void;
-            queryResult(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
-            queryResultSync(sql: string, bindingParameters?: any[]): ODBCResult;
-            prepare(sql: string, cb: (err: any, statement: ODBCStatement) => void): void;
-            prepareSync(sql: string): ODBCStatement;
-            beginTransaction(cb: (err: any) => void): void;
-            beginTransactionSync(): void;
-            endTransaction(rollback: boolean, cb: (err: any) => void): void;
-            endTransactionSync(rollback: boolean): void;
-            commitTransaction(cb: (err: any) => void): void;
-            commitTransactionSync(): void;
-            rollbackTransaction(cb: (err: any) => void): void;
-            rollbackTransactionSync(): void;
-            tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCTable[]) => void): void;
-            columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCColumn[]) => void): void;
-            describe(options: DescribeOptions, cb: (err: any, result: (ODBCTable & ODBCColumn)[]) => void): void;
-        }
-
-        export class Pool {
-            constructor(options?: DatabaseOptions);
-            open(connctionString: string, cb: (err: any, db: Database) => void): void;
-            close(cb: (err: any) => void): void;
-        }
-
-        export function open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+    export interface ConnctionInfo {
+        [key: string]: string;
     }
 
-    export = odbc;
+    export interface DatabaseOptions {
+        connectTimeout?: number;
+        loginTimeout?: number;
+    }
+
+    export interface DescribeOptions {
+        database: string;
+        schema?: string;
+        table?: string;
+        type?: string;
+        column?: string;
+    }
+
+    export interface SimpleQueue {
+        push(fn: Function): void;
+        next(): any;
+        maybeNext(): any;
+    }
+
+    export interface ODBCTable {
+        TABLE_CAT: string;
+        TABLE_SCHEM: string;
+        TABLE_NAME: string;
+        TABLE_TYPE: string;
+        REMARKS: string;
+    }
+
+    export interface ODBCColumn {
+        TABLE_CAT: string;
+        TABLE_SCHEM: string;
+        TABLE_NAME: string;
+        COLUMN_NAME: string;
+        DATA_TYPE: number;
+        TYPE_NAME: string;
+        COLUMN_SIZE: number;
+        BUFFER_LENGTH: number;
+        DECIMAL_DIGITS: number;
+        NUM_PREC_RADIX: number;
+        NULLABLE: number;
+        REMARKS: string;
+        COLUMN_DEF: string;
+        SQL_DATA_TYPE: number;
+        SQL_DATETIME_SUB: number;
+        CHAR_OCTET_LENGTH: number;
+        ORDINAL_POSITION: number;
+        IS_NULLABLE: string;
+    }
+
+    export interface ODBCConnection {
+        connected: boolean;
+        connectTimeout: number;
+        loginTimeout: number;
+        open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+        openSync(connctionString: string | ConnctionInfo): void;
+        close(cb: (err: any) => void): void;
+        closeSync(): void;
+        createStatement(cb: (err: any, stmt: ODBCStatement) => void): void;
+        createStatementSync(): ODBCStatement;
+        query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+        query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+        querySync(sql: string, bindingParameters?: any[]): ResultRow[];
+        beginTransaction(cb: (err: any) => void): void;
+        beginTransactionSync(): void;
+        endTransaction(rollback: boolean, cb: (err: any) => void): void;
+        endTransactionSync(rollback: boolean): void;
+        tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCResult) => void): void;
+        columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCResult) => void): void;
+    }
+
+    export interface ResultRow {
+        [key: string]: any;
+    }
+
+    export interface ODBCResult {
+        fetchMode: number;
+        fetchAll(cb: (err: any, data: ResultRow[]) => void): void;
+        fetchAllSync(): ResultRow[];
+        fetch(cb: (err: any, data: ResultRow) => void): void;
+        fetchSync(): ResultRow;
+        closeSync(): void;
+        moreResultsSync(): any;
+        getColumnNamesSync(): string[];
+    }
+
+    export interface ODBCStatement {
+        queue: SimpleQueue;
+        execute(cb: (err: any, result: ODBCResult) => void): void;
+        execute(bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+        executeSync(bindingParameters?: any[]): ODBCResult;
+        executeDirect(sql: string, cb: (err: any, result: ODBCResult) => void): void;
+        executeDirect(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+        executeDirectSync(sql: string, bindingParameters?: any[]): ODBCResult;
+        executeNonQuery(cb: (err: any, result: number) => void): void;
+        executeNonQuery(bindingParameters: any[], cb: (err: any, result: number) => void): void;
+        executeNonQuerySync(bindingParameters?: any[]): number;
+        prepare(sql: string, cb: (err: any) => void): void;
+        prepareSync(sql: string): void;
+        bind(bindingParameters: any[], cb: (err: any) => void): void;
+        bindSync(bindingParameters: any[]): void;
+        closeSync(): void;
+    }
+
+    export class Database {
+        constructor(options?: DatabaseOptions);
+        conn: ODBCConnection;
+        queue: SimpleQueue;
+        connected: boolean;
+        connectTimeout: number;
+        loginTimeout: number;
+        SQL_CLOSE: number;
+        SQL_DROP: number;
+        SQL_UNBIND: number;
+        SQL_RESET_PARAMS: number;
+        SQL_DESTROY: number;
+        FETCH_ARRAY: number;
+        FETCH_OBJECT: number;
+        open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+        openSync(connctionString: string | ConnctionInfo): void;
+        close(cb: (err: any) => void): void;
+        closeSync(): void;
+        query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+        query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+        querySync(sql: string, bindingParameters?: any[]): ResultRow[];
+        queryResult(sql: string, cb: (err: any, result: ODBCResult) => void): void;
+        queryResult(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+        queryResultSync(sql: string, bindingParameters?: any[]): ODBCResult;
+        prepare(sql: string, cb: (err: any, statement: ODBCStatement) => void): void;
+        prepareSync(sql: string): ODBCStatement;
+        beginTransaction(cb: (err: any) => void): void;
+        beginTransactionSync(): void;
+        endTransaction(rollback: boolean, cb: (err: any) => void): void;
+        endTransactionSync(rollback: boolean): void;
+        commitTransaction(cb: (err: any) => void): void;
+        commitTransactionSync(): void;
+        rollbackTransaction(cb: (err: any) => void): void;
+        rollbackTransactionSync(): void;
+        tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCTable[]) => void): void;
+        columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCColumn[]) => void): void;
+        describe(options: DescribeOptions, cb: (err: any, result: (ODBCTable & ODBCColumn)[]) => void): void;
+    }
+
+    export class Pool {
+        constructor(options?: DatabaseOptions);
+        open(connctionString: string, cb: (err: any, db: Database) => void): void;
+        close(cb: (err: any) => void): void;
+    }
+
+    export function open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
 }
+
+export = odbc;

--- a/lib/odbc.d.ts
+++ b/lib/odbc.d.ts
@@ -1,0 +1,170 @@
+declare module 'odbc' {
+    function odbc(options?: odbc.DatabaseOptions): odbc.Database;
+
+    namespace odbc {
+        export const SQL_CLOSE: number;
+        export const SQL_DROP: number;
+        export const SQL_UNBIND: number;
+        export const SQL_RESET_PARAMS: number;
+        export const SQL_DESTROY: number;
+        export const FETCH_ARRAY: number;
+        export const FETCH_OBJECT: number;
+
+        export let debug: boolean;
+
+        export interface ConnctionInfo {
+            [key: string]: string;
+        }
+
+        export interface DatabaseOptions {
+            connectTimeout?: number;
+            loginTimeout?: number;
+        }
+
+        export interface DescribeOptions {
+            database: string;
+            schema?: string;
+            table?: string;
+            type?: string;
+            column?: string;
+        }
+
+        export interface SimpleQueue {
+            push(fn: Function): void;
+            next(): any;
+            maybeNext(): any;
+        }
+
+        export interface ODBCTable {
+            TABLE_CAT: string;
+            TABLE_SCHEM: string;
+            TABLE_NAME: string;
+            TABLE_TYPE: string;
+            REMARKS: string;
+        }
+
+        export interface ODBCColumn {
+            TABLE_CAT: string;
+            TABLE_SCHEM: string;
+            TABLE_NAME: string;
+            COLUMN_NAME: string;
+            DATA_TYPE: number;
+            TYPE_NAME: string;
+            COLUMN_SIZE: number;
+            BUFFER_LENGTH: number;
+            DECIMAL_DIGITS: number;
+            NUM_PREC_RADIX: number;
+            NULLABLE: number;
+            REMARKS: string;
+            COLUMN_DEF: string;
+            SQL_DATA_TYPE: number;
+            SQL_DATETIME_SUB: number;
+            CHAR_OCTET_LENGTH: number;
+            ORDINAL_POSITION: number;
+            IS_NULLABLE: string;
+        }
+
+        export interface ODBCConnection {
+            connected: boolean;
+            connectTimeout: number;
+            loginTimeout: number;
+            open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+            openSync(connctionString: string | ConnctionInfo): void;
+            close(cb: (err: any) => void): void;
+            closeSync(): void;
+            createStatement(cb: (err: any, stmt: ODBCStatement) => void): void;
+            createStatementSync(): ODBCStatement;
+            query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+            query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+            querySync(sql: string, bindingParameters?: any[]): ResultRow[];
+            beginTransaction(cb: (err: any) => void): void;
+            beginTransactionSync(): void;
+            endTransaction(rollback: boolean, cb: (err: any) => void): void;
+            endTransactionSync(rollback: boolean): void;
+            tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCResult) => void): void;
+            columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCResult) => void): void;
+        }
+
+        export interface ResultRow {
+            [key: string]: any;
+        }
+
+        export interface ODBCResult {
+            fetchMode: number;
+            fetchAll(cb: (err: any, data: ResultRow[]) => void): void;
+            fetchAllSync(): ResultRow[];
+            fetch(cb: (err: any, data: ResultRow) => void): void;
+            fetchSync(): ResultRow;
+            closeSync(): void;
+            moreResultsSync(): any;
+            getColumnNamesSync(): string[];
+        }
+
+        export interface ODBCStatement {
+            queue: SimpleQueue;
+            execute(cb: (err: any, result: ODBCResult) => void): void;
+            execute(bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+            executeSync(bindingParameters?: any[]): ODBCResult;
+            executeDirect(sql: string, cb: (err: any, result: ODBCResult) => void): void;
+            executeDirect(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+            executeDirectSync(sql: string, bindingParameters?: any[]): ODBCResult;
+            executeNonQuery(cb: (err: any, result: number) => void): void;
+            executeNonQuery(bindingParameters: any[], cb: (err: any, result: number) => void): void;
+            executeNonQuerySync(bindingParameters?: any[]): number;
+            prepare(sql: string, cb: (err: any) => void): void;
+            prepareSync(sql: string): void;
+            bind(bindingParameters: any[], cb: (err: any) => void): void;
+            bindSync(bindingParameters: any[]): void;
+            closeSync(): void;
+        }
+
+        export class Database {
+            constructor(options?: DatabaseOptions);
+            conn: ODBCConnection;
+            queue: SimpleQueue;
+            connected: boolean;
+            connectTimeout: number;
+            loginTimeout: number;
+            SQL_CLOSE: number;
+            SQL_DROP: number;
+            SQL_UNBIND: number;
+            SQL_RESET_PARAMS: number;
+            SQL_DESTROY: number;
+            FETCH_ARRAY: number;
+            FETCH_OBJECT: number;
+            open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+            openSync(connctionString: string | ConnctionInfo): void;
+            close(cb: (err: any) => void): void;
+            closeSync(): void;
+            query(sql: string, cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+            query(sql: string, bindingParameters: any[], cb: (err: any, rows: ResultRow[], moreResultSets: any) => void): void;
+            querySync(sql: string, bindingParameters?: any[]): ResultRow[];
+            queryResult(sql: string, cb: (err: any, result: ODBCResult) => void): void;
+            queryResult(sql: string, bindingParameters: any[], cb: (err: any, result: ODBCResult) => void): void;
+            queryResultSync(sql: string, bindingParameters?: any[]): ODBCResult;
+            prepare(sql: string, cb: (err: any, statement: ODBCStatement) => void): void;
+            prepareSync(sql: string): ODBCStatement;
+            beginTransaction(cb: (err: any) => void): void;
+            beginTransactionSync(): void;
+            endTransaction(rollback: boolean, cb: (err: any) => void): void;
+            endTransactionSync(rollback: boolean): void;
+            commitTransaction(cb: (err: any) => void): void;
+            commitTransactionSync(): void;
+            rollbackTransaction(cb: (err: any) => void): void;
+            rollbackTransactionSync(): void;
+            tables(catalog: string | null, schema: string | null, table: string | null, type: string | null, cb: (err: any, result: ODBCTable[]) => void): void;
+            columns(catalog: string | null, schema: string | null, table: string | null, column: string | null, cb: (err: any, result: ODBCColumn[]) => void): void;
+            describe(options: DescribeOptions, cb: (err: any, result: (ODBCTable & ODBCColumn)[]) => void): void;
+        }
+
+        export class Pool {
+            constructor(options?: DatabaseOptions);
+            open(connctionString: string, cb: (err: any, db: Database) => void): void;
+            close(cb: (err: any) => void): void;
+        }
+
+        export function open(connctionString: string | ConnctionInfo, cb: (err: any, result: any) => void): void;
+    }
+
+    export = odbc;
+}

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -66,6 +66,7 @@ function Database(options) {
   }
   
   self.odbc = (options.odbc) ? options.odbc : new odbc.ODBC();
+  self.odbc.domain = process.domain;
   self.queue = new SimpleQueue();
   self.fetchMode = options.fetchMode || null;
   self.connected = false;
@@ -106,6 +107,7 @@ Database.prototype.open = function (connectionString, cb) {
     if (err) return cb(err);
     
     self.conn = conn;
+    self.conn.domain = process.domain;
     
     if (self.connectTimeout || self.connectTimeout === 0) {
       self.conn.connectTimeout = self.connectTimeout;

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -197,12 +197,16 @@ Database.prototype.query = function (sql, params, cb) {
     params = null;
   }
   
-   if (!self.connected) {
+  if (!self.connected) {
     return cb({ message : "Connection not open."}, [], false);
   }
   
   self.queue.push(function (next) {
     function cbQuery (initialErr, result) {
+      if (!self.connected) {
+        return cb({ message : "Connection not open."}, [], false);
+      }
+
       fetchMore();
       
       function fetchMore() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "main": "lib/odbc.js",
   "types": "./lib/odbc.d.ts",
   "homepage": "http://github.com/wankdanker/node-odbc/",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "unixodbc bindings for node",
   "version": "1.2.1",
   "main": "lib/odbc.js",
+  "types": "./lib/odbc.d.ts",
   "homepage": "http://github.com/wankdanker/node-odbc/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "lib/odbc.js",
   "homepage": "http://github.com/wankdanker/node-odbc/",
   "repository": {

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -686,13 +686,12 @@ Parameter* ODBC::GetParametersFromArray (Local<Array> values, int *paramCount) {
 
     if (value->IsString()) {
       Local<String> string = value->ToString();
-      int length = string->Length();
       
       params[i].ValueType         = SQL_C_TCHAR;
       params[i].ColumnSize        = 0; //SQL_SS_LENGTH_UNLIMITED 
 #ifdef UNICODE
       params[i].ParameterType     = SQL_WVARCHAR;
-      params[i].BufferLength      = (length * sizeof(uint16_t)) + sizeof(uint16_t);
+      params[i].BufferLength      = (string->Length() * sizeof(uint16_t)) + sizeof(uint16_t);
 #else
       params[i].ParameterType     = SQL_VARCHAR;
       params[i].BufferLength      = string->Utf8Length() + 1;

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -39,7 +39,6 @@ using namespace v8;
 using namespace node;
 
 uv_mutex_t ODBC::g_odbcMutex;
-uv_async_t ODBC::g_async;
 
 Nan::Persistent<Function> ODBC::constructor;
 
@@ -79,22 +78,6 @@ void ODBC::Init(v8::Handle<Object> exports) {
   constructor.Reset(constructor_template->GetFunction());
   exports->Set(Nan::New("ODBC").ToLocalChecked(),
                constructor_template->GetFunction());
-  
-#if NODE_VERSION_AT_LEAST(0, 7, 9)
-  // Initialize uv_async so that we can prevent node from exiting
-  //uv_async_init( uv_default_loop(),
-  //               &ODBC::g_async,
-  //               ODBC::WatcherCallback);
-  
-  // Not sure if the init automatically calls uv_ref() because there is weird
-  // behavior going on. When ODBC::Init is called which initializes the 
-  // uv_async_t g_async above, there seems to be a ref which will keep it alive
-  // but we only want this available so that we can uv_ref() later on when
-  // we have a connection.
-  // so to work around this, I am possibly mistakenly calling uv_unref() once
-  // so that there are no references on the loop.
-  //uv_unref((uv_handle_t *)&ODBC::g_async);
-#endif
   
   // Initialize the cross platform mutex provided by libuv
   uv_mutex_init(&ODBC::g_odbcMutex);

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -226,7 +226,7 @@ void ODBC::UV_AfterCreateConnection(uv_work_t* req, int status) {
     info[0] = Nan::Null();
     info[1] = js_result;
 
-    data->cb->Call(2, info);
+    data->cb->Call(data->dbo->handle(), 2, info);
   }
   
   if (try_catch.HasCaught()) {

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -819,7 +819,7 @@ Local<Object> ODBC::GetSQLError (SQLSMALLINT handleType, SQLHANDLE handle, char*
   
   Local<Object> objError = Nan::New<Object>();
 
-  SQLINTEGER i = 0;
+  int32_t i = 0;
   SQLINTEGER native;
   
   SQLSMALLINT len;

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -75,7 +75,6 @@ class ODBC : public Nan::ObjectWrap {
   public:
     static Nan::Persistent<Function> constructor;
     static uv_mutex_t g_odbcMutex;
-    static uv_async_t g_async;
     
     static void Init(v8::Handle<Object> exports);
     static Column* GetColumns(SQLHSTMT hStmt, short* colCount);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -319,7 +319,7 @@ void ODBCConnection::UV_AfterOpen(uv_work_t* req, int status) {
   Nan::TryCatch try_catch;
 
   data->conn->Unref();
-  data->cb->Call(err ? 1 : 0, argv);
+  data->cb->Call(data->conn->handle(), err ? 1 : 0, argv);
 
   if (try_catch.HasCaught()) {
     Nan::FatalException(try_catch);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -194,13 +194,13 @@ NAN_METHOD(ODBCConnection::Open) {
   open_connection_work_data* data = (open_connection_work_data *) 
     calloc(1, sizeof(open_connection_work_data));
 
-  data->connectionLength = connection->Length() + 1;
-
   //copy the connection string to the work data  
 #ifdef UNICODE
+  data->connectionLength = connection->Length() + 1;
   data->connection = (uint16_t *) malloc(sizeof(uint16_t) * data->connectionLength);
   connection->Write((uint16_t*) data->connection);
 #else
+  data->connectionLength = connection->Utf8Length() + 1;
   data->connection = (char *) malloc(sizeof(char) * data->connectionLength);
   connection->WriteUtf8((char*) data->connection);
 #endif
@@ -351,12 +351,12 @@ NAN_METHOD(ODBCConnection::OpenSync) {
   SQLRETURN ret;
   bool err = false;
   
-  int connectionLength = connection->Length() + 1;
-  
 #ifdef UNICODE
+  int connectionLength = connection->Length() + 1;
   uint16_t* connectionString = (uint16_t *) malloc(connectionLength * sizeof(uint16_t));
   connection->Write(connectionString);
 #else
+  int connectionLength = connection->Utf8Length() + 1;
   char* connectionString = (char *) malloc(connectionLength);
   connection->WriteUtf8(connectionString);
 #endif
@@ -791,14 +791,15 @@ NAN_METHOD(ODBCConnection::Query) {
   //Done checking arguments
 
   data->cb = new Nan::Callback(cb);
-  data->sqlLen = sql->Length();
 
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sqlSize = (data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t);
   data->sql = (uint16_t *) malloc(data->sqlSize);
   sql->Write((uint16_t *) data->sql);
 #else
-  data->sqlSize = sql->Utf8Length() + 1;
+  data->sqlLen = sql->Utf8Length();
+  data->sqlSize = data->sqlLen + 1;
   data->sql = (char *) malloc(data->sqlSize);
   sql->WriteUtf8((char *) data->sql);
 #endif
@@ -1208,7 +1209,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->catalog = (uint16_t *) malloc((catalog->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     catalog->Write((uint16_t *) data->catalog);
 #else
-    data->catalog = (char *) malloc(catalog->Length() + 1);
+    data->catalog = (char *) malloc(catalog->Utf8Length() + 1);
     catalog->WriteUtf8((char *) data->catalog);
 #endif
   }
@@ -1218,7 +1219,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->schema = (uint16_t *) malloc((schema->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     schema->Write((uint16_t *) data->schema);
 #else
-    data->schema = (char *) malloc(schema->Length() + 1);
+    data->schema = (char *) malloc(schema->Utf8Length() + 1);
     schema->WriteUtf8((char *) data->schema);
 #endif
   }
@@ -1228,7 +1229,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->table = (uint16_t *) malloc((table->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     table->Write((uint16_t *) data->table);
 #else
-    data->table = (char *) malloc(table->Length() + 1);
+    data->table = (char *) malloc(table->Utf8Length() + 1);
     table->WriteUtf8((char *) data->table);
 #endif
   }
@@ -1238,7 +1239,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->type = (uint16_t *) malloc((type->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     type->Write((uint16_t *) data->type);
 #else
-    data->type = (char *) malloc(type->Length() + 1);
+    data->type = (char *) malloc(type->Utf8Length() + 1);
     type->WriteUtf8((char *) data->type);
 #endif
   }
@@ -1319,7 +1320,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->catalog = (uint16_t *) malloc((catalog->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     catalog->Write((uint16_t *) data->catalog);
 #else
-    data->catalog = (char *) malloc(catalog->Length() + 1);
+    data->catalog = (char *) malloc(catalog->Utf8Length() + 1);
     catalog->WriteUtf8((char *) data->catalog);
 #endif
   }
@@ -1329,7 +1330,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->schema = (uint16_t *) malloc((schema->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     schema->Write((uint16_t *) data->schema);
 #else
-    data->schema = (char *) malloc(schema->Length() + 1);
+    data->schema = (char *) malloc(schema->Utf8Length() + 1);
     schema->WriteUtf8((char *) data->schema);
 #endif
   }
@@ -1339,7 +1340,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->table = (uint16_t *) malloc((table->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     table->Write((uint16_t *) data->table);
 #else
-    data->table = (char *) malloc(table->Length() + 1);
+    data->table = (char *) malloc(table->Utf8Length() + 1);
     table->WriteUtf8((char *) data->table);
 #endif
   }
@@ -1349,7 +1350,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->column = (uint16_t *) malloc((column->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     column->Write((uint16_t *) data->column);
 #else
-    data->column = (char *) malloc(column->Length() + 1);
+    data->column = (char *) malloc(column->Utf8Length() + 1);
     column->WriteUtf8((char *) data->column);
 #endif
   }

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -307,13 +307,6 @@ void ODBCConnection::UV_AfterOpen(uv_work_t* req, int status) {
 
   if (!err) {
    data->conn->self()->connected = true;
-    
-    //only uv_ref if the connection was successful
-//#if NODE_VERSION_AT_LEAST(0, 7, 9)
-//    uv_ref((uv_handle_t *)&ODBC::g_async);
-//#else
-//    uv_ref(uv_default_loop());
-//#endif
   }
 
   Nan::TryCatch try_catch;
@@ -419,13 +412,6 @@ NAN_METHOD(ODBCConnection::OpenSync) {
     ret = SQLFreeHandle( SQL_HANDLE_STMT, hStmt);
     
     conn->self()->connected = true;
-    
-    //only uv_ref if the connection was successful
-    /*#if NODE_VERSION_AT_LEAST(0, 7, 9)
-      uv_ref((uv_handle_t *)&ODBC::g_async);
-    #else
-      uv_ref(uv_default_loop());
-    #endif*/
   }
 
   uv_mutex_unlock(&ODBC::g_odbcMutex);
@@ -504,13 +490,6 @@ void ODBCConnection::UV_AfterClose(uv_work_t* req, int status) {
   }
   else {
     conn->connected = false;
-    
-    //only unref if the connection was closed
-//#if NODE_VERSION_AT_LEAST(0, 7, 9)
-//    uv_unref((uv_handle_t *)&ODBC::g_async);
-//#else
-//    uv_unref(uv_default_loop());
-//#endif
   }
 
   Nan::TryCatch try_catch;
@@ -545,12 +524,6 @@ NAN_METHOD(ODBCConnection::CloseSync) {
   
   conn->connected = false;
 
-#if NODE_VERSION_AT_LEAST(0, 7, 9)
-  uv_unref((uv_handle_t *)&ODBC::g_async);
-#else
-  uv_unref(uv_default_loop());
-#endif
-  
   info.GetReturnValue().Set(Nan::True());
 }
 

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -439,12 +439,12 @@ NAN_METHOD(ODBCStatement::ExecuteDirect) {
 
   data->cb = new Nan::Callback(cb);
 
-  data->sqlLen = sql->Length();
-
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sql = (uint16_t *) malloc((data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t));
   sql->Write((uint16_t *) data->sql);
 #else
+  data->sqlLen = sql->Utf8Length();
   data->sql = (char *) malloc(data->sqlLen +1);
   sql->WriteUtf8((char *) data->sql);
 #endif
@@ -591,15 +591,13 @@ NAN_METHOD(ODBCStatement::PrepareSync) {
 
   SQLRETURN ret;
 
-  int sqlLen = sql->Length() + 1;
-
 #ifdef UNICODE
-  uint16_t *sql2;
-  sql2 = (uint16_t *) malloc(sqlLen * sizeof(uint16_t));
+  int sqlLen = sql->Length() + 1;
+  uint16_t* sql2 = (uint16_t *) malloc(sqlLen * sizeof(uint16_t));
   sql->Write(sql2);
 #else
-  char *sql2;
-  sql2 = (char *) malloc(sqlLen);
+  int sqlLen = sql->Utf8Length() + 1;
+  char* sql2 = (char *) malloc(sqlLen);
   sql->WriteUtf8(sql2);
 #endif
   
@@ -646,12 +644,12 @@ NAN_METHOD(ODBCStatement::Prepare) {
 
   data->cb = new Nan::Callback(cb);
 
-  data->sqlLen = sql->Length();
-
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sql = (uint16_t *) malloc((data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t));
   sql->Write((uint16_t *) data->sql);
 #else
+  data->sqlLen = sql->Utf8Length();
   data->sql = (char *) malloc(data->sqlLen +1);
   sql->WriteUtf8((char *) data->sql);
 #endif

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -832,8 +832,6 @@ NAN_METHOD(ODBCStatement::BindSync) {
     
     info.GetReturnValue().Set(Nan::False());
   }
-
-  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*

--- a/test/test-binding-statement-executeSync.js
+++ b/test/test-binding-statement-executeSync.js
@@ -62,7 +62,7 @@ db.createConnection(function (err, conn) {
       console.log(r);
     }
     catch (e) {
-      console.log(e);
+      console.log(e.stack);
       
       exitCode = 1;
     }

--- a/test/test-binding-statement-rebinding.js
+++ b/test/test-binding-statement-rebinding.js
@@ -39,7 +39,7 @@ db.createConnection(function (err, conn) {
       assert.deepEqual(r, [ { col1: 'goodbye', col2: 'steven' } ]);
     }
     catch (e) {
-      console.log(e);
+      console.log(e.stack);
       exitCode = 1;
     }
     

--- a/test/test-binding-statement-rebinding.js
+++ b/test/test-binding-statement-rebinding.js
@@ -5,12 +5,6 @@ var common = require("./common")
   , exitCode = 0
   ;
 
-/*
- * The purpose of this test is to test binding an array and then
- * changing the values of the array before an execute[Sync]
- * call and have the new array values be used.
- */
-  
 db.createConnection(function (err, conn) {
   conn.openSync(common.connectionString);
   
@@ -30,6 +24,7 @@ db.createConnection(function (err, conn) {
     
     a[0] = 'goodbye';
     a[1] = 'steven';
+    stmt.bindSync(a);
     
     result = stmt.executeSync();
     

--- a/test/test-binding-transaction-commitSync.js
+++ b/test/test-binding-transaction-commitSync.js
@@ -22,7 +22,7 @@ db.createConnection(function (err, conn) {
     }
     catch (e) {
       console.log("Failed when rolling back");
-      console.log(e);
+      console.log(e.stack);
       exitCode = 1
     }  
       
@@ -40,7 +40,7 @@ db.createConnection(function (err, conn) {
     }
     catch (e) {
       console.log("Failed when committing");
-      console.log(e);
+      console.log(e.stack);
       
       exitCode = 2;
     }

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -11,6 +11,7 @@ db.open(common.connectionString, function(err) {
   assert.equal(db.connected, true);
   
   var dt = new Date();
+  dt.setMilliseconds(0);  // MySQL truncates them.
   var ds = dt.toISOString().replace('Z','');
   var sql = "SELECT cast('" + ds + "' as datetime) as DT1";
   // XXX(bnoordhuis) sqlite3 has no distinct DATETIME or TIMESTAMP type.
@@ -34,7 +35,10 @@ db.open(common.connectionString, function(err) {
         assert.equal(data[0].DT1, ds.replace('T', ' ').replace(/\.\d+$/, ''));
       } else {
         assert.equal(data[0].DT1.constructor.name, "Date", "DT1 is not an instance of a Date object");
-        assert.equal(data[0].DT1.getTime(), dt.getTime());
+        // XXX(bnoordhuis) DT1 is in local time but we inserted
+        // a UTC date so we need to adjust it before comparing.
+        dt = new Date(dt.getTime() + 6e4 * dt.getTimezoneOffset());
+        assert.equal(data[0].DT1.toISOString(), dt.toISOString());
       }
     });
   });

--- a/test/test-multi-openSync-closeSync.js
+++ b/test/test-multi-openSync-closeSync.js
@@ -16,7 +16,7 @@ for (var x = 0; x < openCount; x++ ) {
   }
   catch (e) {
     console.log(common.connectionString);
-    console.log(e);
+    console.log(e.stack);
     errorCount += 1;
     break;
   }

--- a/test/test-openSync.js
+++ b/test/test-openSync.js
@@ -18,7 +18,7 @@ try {
   db.openSync(common.connectionString);
 }
 catch(e) {
-  console.log(e);
+  console.log(e.stack);
   assert.deepEqual(e, null);
 }
 
@@ -26,6 +26,6 @@ try {
   db.closeSync();
 }
 catch(e) {
-  console.log(e);
+  console.log(e.stack);
   assert.deepEqual(e, null);
 }

--- a/test/test-query-create-table-fetchSync.js
+++ b/test/test-query-create-table-fetchSync.js
@@ -15,7 +15,7 @@ db.queryResult("create table " + common.tableName + " (COLINT INTEGER, COLDATETI
     console.log(data);
   }
   catch (e) {
-    console.log(e);
+    console.log(e.stack);
   }
   
   db.closeSync();

--- a/test/test-querySync-select-unicode.js
+++ b/test/test-querySync-select-unicode.js
@@ -11,7 +11,7 @@ try {
   data = db.querySync("select 'ꜨꜢ' as UNICODETEXT");
 }
 catch (e) {
-  console.log(e); 
+  console.log(e.stack);
 }
 
 db.closeSync();

--- a/test/test-querySync-select-with-execption.js
+++ b/test/test-querySync-select-with-execption.js
@@ -12,7 +12,7 @@ try {
   var data = db.querySync("select invalid query");
 }
 catch (e) {
-  console.log(e);
+  console.log(e.stack);
   
   err = e;
 }

--- a/test/test-transaction-commit-sync.js
+++ b/test/test-transaction-commit-sync.js
@@ -22,7 +22,7 @@ common.createTables(db, function (err, data) {
   }
   catch (e) {
     console.log("Failed when rolling back");
-    console.log(e);
+    console.log(e.stack);
     exitCode = 1
   }  
     
@@ -40,7 +40,7 @@ common.createTables(db, function (err, data) {
   }
   catch (e) {
     console.log("Failed when committing");
-    console.log(e);
+    console.log(e.stack);
     
     exitCode = 2;
   }


### PR DESCRIPTION
Queries are added to the queue to limit concurrency. It's possible that a query can be attempted on 
a closed connection. Although a guard is in place to prevent adding a query to the queue when there is no open connection, there is no similar check immediately before the query is dispatched to the connection. A lot can happen to a connection between enqueuing and execution.