### PR TITLE
Check for an open connection at execution time

### DIFF
--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -197,12 +197,16 @@ Database.prototype.query = function (sql, params, cb) {
     params = null;
   }
   
-   if (!self.connected) {
+  if (!self.connected) {
     return cb({ message : "Connection not open."}, [], false);
   }
   
   self.queue.push(function (next) {
     function cbQuery (initialErr, result) {
+      if (!self.connected) {
+        return cb({ message : "Connection not open."}, [], false);
+      }
+
       fetchMore();
       
       function fetchMore() {


### PR DESCRIPTION
Queries are added to the queue to limit concurrency. It's possible that a query can be attempted on
a closed connection. Although a guard is in place to prevent adding a query to the queue when there is no open connection, there is no similar check immediately before the query is dispatched to the connection. A lot can happen to a connection between enqueuing and execution.